### PR TITLE
getEnvironment should be in the current context, not a static method

### DIFF
--- a/vars/getCIMessage.groovy
+++ b/vars/getCIMessage.groovy
@@ -34,8 +34,10 @@ import groovy.json.*
 //    }
 //}
 
-def call(String message) {
-
+def call() {
+    def message = getEnvironment(listener).get('CI_MESSAGE')
+    echo message
+    
     def json = new JsonSlurper().parseText(message)
     println "CI_MESSAGE=$message"
 }


### PR DESCRIPTION
In theory, the current run object should be the context of the job we're running in.... so this *should* work.

Also, Run.getEnvironment is not a static method, so it makes sense that this would fail.